### PR TITLE
WIKI-1001 [Export to PDF] Unknown error when exporting wiki page of less...

### DIFF
--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/ExportAsPDFActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/ExportAsPDFActionComponent.java
@@ -110,6 +110,9 @@ public class ExportAsPDFActionComponent extends AbstractEventActionComponent {
     private File createPDFFile(String title, String content) throws IOException {
       File pdfFile = null;
       OutputStream os = null;
+      if (title.length() < 3) {
+        title += "tmp";
+      }
       try {
         pdfFile = File.createTempFile(title, ".pdf");
         os = new FileOutputStream(pdfFile);


### PR DESCRIPTION
... than 3 characters in the title

Problem analysis:
* Java's File.createTempFile requires the file name (page title in this case) of at least 3 characters.

Fix description:
* When creating temporary file, add "tmp" to the end of page title if it is less than 3 characters long.
  This overcomes Java's File.createTempFile constraint and doesn't impact the output file name the user has.