### PR TITLE
WIKI-1110 : remove JCR path from search results objects

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/mow/core/api/wiki/JCRSearchResult.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/mow/core/api/wiki/JCRSearchResult.java
@@ -1,0 +1,19 @@
+package org.exoplatform.wiki.mow.core.api.wiki;
+
+import org.exoplatform.wiki.service.search.SearchResult;
+
+/**
+ * SearchResult for JCR
+ */
+public class JCRSearchResult extends SearchResult {
+
+  protected String path;
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+  public String getPath() {
+    return path;
+  }
+
+}

--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
@@ -16,11 +16,31 @@
  */
 package org.exoplatform.wiki.service.impl;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.Class;
+import java.lang.Object;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.*;
+
+import javax.annotation.security.RolesAllowed;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import javax.ws.rs.core.Response.Status;
+
 import org.apache.commons.fileupload.DiskFileUpload;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.rendering.syntax.Syntax;
+
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.commons.utils.MimeTypeResolver;
 import org.exoplatform.container.ExoContainerContext;
@@ -54,24 +74,6 @@ import org.exoplatform.wiki.tree.utils.TreeUtils;
 import org.exoplatform.wiki.utils.Utils;
 import org.exoplatform.wiki.utils.WikiConstants;
 import org.exoplatform.wiki.utils.WikiNameValidator;
-import org.xwiki.context.Execution;
-import org.xwiki.context.ExecutionContext;
-import org.xwiki.rendering.syntax.Syntax;
-
-import javax.annotation.security.RolesAllowed;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import javax.ws.rs.core.Response.Status;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.lang.Class;
-import java.lang.Object;
-import java.net.URI;
-import java.net.URLDecoder;
-import java.util.*;
 
 /**
  * {@inheritDoc}
@@ -554,9 +556,9 @@ public class WikiRestServiceImpl implements WikiRestService, ResourceContainer {
         if(page != null) {
           if (SearchResultType.ATTACHMENT.equals(searchResult.getType())) {
             org.exoplatform.wiki.mow.api.Attachment attachment = wikiService.getAttachmentOfPageByName(searchResult.getAttachmentName(), page);
-            titleSearchResults.add(new TitleSearchResult(attachment.getName(), searchResult.getPath(), searchResult.getType(), attachment.getDownloadURL()));
+            titleSearchResults.add(new TitleSearchResult(attachment.getName(), searchResult.getType(), attachment.getDownloadURL()));
           } else {
-            titleSearchResults.add(new TitleSearchResult(searchResult.getTitle(), searchResult.getPath(), searchResult.getType(), page.getUrl()));
+            titleSearchResults.add(new TitleSearchResult(searchResult.getTitle(), searchResult.getType(), page.getUrl()));
           }
         } else {
           log.warn("Cannot get page of search result " + searchResult.getWikiType() + ":" + searchResult.getWikiOwner() + ":" + searchResult.getPageName());

--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
@@ -715,8 +715,8 @@ public class WikiServiceImpl implements WikiService, Startable {
           Calendar wikiHomeUpdateDate = Calendar.getInstance();
           wikiHomeUpdateDate.setTime(homePage.getUpdatedDate());
 
-          SearchResult wikiHomeResult = new SearchResult(data.getWikiType(), data.getWikiOwner(), data.getPageId(),
-                  null, null, homePage.getTitle(), null, SearchResultType.PAGE, wikiHomeUpdateDate, wikiHomeCreateDate);
+          SearchResult wikiHomeResult = new SearchResult(data.getWikiType(), data.getWikiOwner(), homePage.getName(),
+                  null, null, homePage.getTitle(), SearchResultType.PAGE, wikiHomeUpdateDate, wikiHomeCreateDate);
           List<SearchResult> tempSearchResult = result.getAll();
           tempSearchResult.add(wikiHomeResult);
           result = new ObjectPageList<>(tempSearchResult, result.getPageSize());

--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/search/SearchResult.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/search/SearchResult.java
@@ -11,7 +11,6 @@ public class SearchResult {
   protected String attachmentName;
   protected String excerpt;
   protected String title;
-  protected String path;
   protected SearchResultType type;
   protected String url;
   protected long score;
@@ -21,18 +20,16 @@ public class SearchResult {
   public SearchResult() {}
   
   public SearchResult(String wikiType, String wikiOwner, String pageName, String attachmentName, String excerpt,
-                      String title, String path, SearchResultType type, Calendar updatedDate, Calendar createdDate) {
+                      String title, SearchResultType type, Calendar updatedDate, Calendar createdDate) {
     this.wikiType = wikiType;
     this.wikiOwner = wikiOwner;
     this.pageName = pageName;
     this.attachmentName = attachmentName;
     this.excerpt = excerpt;
     this.title = title;
-    this.path = path;
     this.type = type;
     this.updatedDate = updatedDate;
     this.createdDate = createdDate;
-    evaluatePageName(path);
   }
 
   public String getWikiType() {
@@ -74,13 +71,6 @@ public class SearchResult {
     return title;
   }
   
-  public void setPath(String path) {
-    this.path = path;
-  }
-  public String getPath() {
-    return path;
-  }
-  
   public void setExcerpt(String text) {
     this.excerpt = text;
   }
@@ -95,15 +85,6 @@ public class SearchResult {
 
   public SearchResultType getType() {
     return type;
-  }
-  
-  private void evaluatePageName(String path) {
-    if (SearchResultType.PAGE.equals(type)) {
-      this.setPageName(path.substring(path.lastIndexOf("/")));
-    } else if (SearchResultType.ATTACHMENT.equals(type) || SearchResultType.PAGE_CONTENT.equals(type)) {
-      String temp = path.substring(0, path.lastIndexOf("/"));
-      this.setPageName(temp.substring(temp.lastIndexOf("/")));
-    }
   }
   
   public void setUrl(String url) {

--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/search/TemplateSearchResult.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/search/TemplateSearchResult.java
@@ -32,12 +32,11 @@ public class TemplateSearchResult extends SearchResult {
                               String wikiOwner,
                               String name,
                               String title,
-                              String path,
                               SearchResultType type,
                               Calendar updatedDate,
                               Calendar createdDate,
                               String description) {
-    super(wikiType, wikiOwner, null, null, null, title, path, type, updatedDate, createdDate);
+    super(wikiType, wikiOwner, null, null, null, title, type, updatedDate, createdDate);
     this.description = description;
     this.name = name;
   }

--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/search/TitleSearchResult.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/search/TitleSearchResult.java
@@ -21,14 +21,11 @@ public class TitleSearchResult {
 
   private SearchResultType type;
 
-  private String path;
-
   private String url;
   
-  public TitleSearchResult(String title, String path, SearchResultType type, String url) {
+  public TitleSearchResult(String title, SearchResultType type, String url) {
     this.title = title;
     this.type = type;
-    this.path = path;
     this.url = url;
   }
 
@@ -38,14 +35,6 @@ public class TitleSearchResult {
 
   public void setType(SearchResultType type) {
     this.type = type;
-  }
-
-  public String getPath() {
-    return path;
-  }
-
-  public void setPath(String path) {
-    this.path = path;
   }
   
   public void setTitle(String title) {

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
@@ -240,6 +240,7 @@ public class SavePageActionComponent extends UIComponent {
 
             // Create page
             Wiki wiki = new Wiki(pageParams.getType(), pageParams.getOwner());
+            pageParams.setPageName(newPageName);
             Page newPage = new Page();
             newPage.setName(title);
             newPage.setTitle(title);
@@ -249,7 +250,6 @@ public class SavePageActionComponent extends UIComponent {
             newPage.setSyntax(syntaxId);
             newPage.setUrl(Utils.getURLFromParams(pageParams));
             Page createdPage = wikiService.createPage(wiki, page.getName(), newPage);
-            pageParams.setPageName(newPageName);
 
             // Add all the attachments to the newly created page
             for(Attachment attachment : attachments) {


### PR DESCRIPTION
I removed the JCR path from the SearchResult object (since it is specific to JCR) and created a dedicated object for JCR search results (JCRSearchResult).