### PR TITLE
WIKI-1090 No 'plus' icon in the page tree when a page has children pages

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/tree/PageTreeNode.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/tree/PageTreeNode.java
@@ -45,6 +45,7 @@ public class PageTreeNode extends TreeNode {
 
     this.page = page;
     this.path = buildPath();
+    this.hasChild = !wikiService.getChildrenPageOf(page).isEmpty();
   }
 
   public Page getPage() {

--- a/wiki-service/src/main/java/org/exoplatform/wiki/tree/WikiHomeTreeNode.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/tree/WikiHomeTreeNode.java
@@ -48,6 +48,7 @@ public class WikiHomeTreeNode extends TreeNode {
 
     this.wikiHome = wikiHome;
     this.path = this.buildPath();
+    this.hasChild = !wikiService.getChildrenPageOf(wikiHome).isEmpty();
   }
 
   @Override


### PR DESCRIPTION
Follow by logic of https://github.com/exoplatform/wiki/blob/stable/4.2.x/wiki-service/src/main/java/org/exoplatform/wiki/tree/PageTreeNode.java#L37 and https://github.com/exoplatform/wiki/blob/stable/4.2.x/wiki-service/src/main/java/org/exoplatform/wiki/tree/WikiHomeTreeNode.java#L40 