### PR TITLE
WIKI-1123: Nothing in 'All Pages' tab when link a wiki page

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
@@ -332,12 +332,13 @@ public class WikiRestServiceImpl implements WikiRestService, ResourceContainer {
     Spaces spaces = objectFactory.createSpaces();
     List<String> spaceNames = new ArrayList<>();
     try {
-      Collection<Wiki> wikis = wikiService.getWikisByType(wikiType.toUpperCase());
+      List<Wiki> wikis = wikiService.getWikisByType(wikiType.toUpperCase());
       for (Wiki wiki : wikis) {
-        for (String spaceName : spaceNames) {
-          org.exoplatform.wiki.mow.api.Page page = wiki.getWikiHome();
-          spaces.getSpaces().add(createSpace(objectFactory, uriInfo.getBaseUri(), wikiType, spaceName, page));
-        }
+        spaceNames.add(wiki.getOwner());
+      }
+      for (String spaceName : spaceNames) {
+        org.exoplatform.wiki.mow.api.Page page = wikiService.getPageOfWikiByName(wikiType, spaceName, WikiConstants.WIKI_HOME_NAME);
+        spaces.getSpaces().add(createSpace(objectFactory, uriInfo.getBaseUri(), wikiType, spaceName, page));
       }
     } catch(WikiException e) {
       log.error("Cannot get spaces of wiki type " + wikiType + " - Cause : " + e.getMessage(), e);


### PR DESCRIPTION
Fix: correct wrong logic from commit https://github.com/exodev/wiki/commit/bc312cc19a2c4658bd86d67b1bbd6026d84b1aee#diff-da366bc88fa95ec2a161f032bf669738L330 