### PR TITLE
WIKI-1212 : renders emotion icons in wiki pages

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/rendering/impl/DefaultWikiModel.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/rendering/impl/DefaultWikiModel.java
@@ -137,7 +137,7 @@ public class DefaultWikiModel implements WikiModel {
       } else {
         EmotionIcon emotionIcon = wikiService.getEmotionIconByName(attachmentName);
         if(emotionIcon != null) {
-          sb.append(emotionIcon.getUrl());
+          sb.append("/rest/wiki/emoticons/" + emotionIcon.getName());
         }
       }
     } catch (Exception e) {

--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/JCRDataStorage.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/JCRDataStorage.java
@@ -1344,6 +1344,7 @@ public class JCRDataStorage implements DataStorage {
                   .append("/")
                   .append(emotionIconAttachment.getName());
           emotionIcon.setUrl(sbUrl.toString());
+          emotionIcon.setImage(emotionIconAttachment.getContentResource().getData());
         }
       }
 

--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
@@ -37,6 +37,7 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.wiki.mow.api.EmotionIcon;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.rendering.syntax.Syntax;
@@ -1112,6 +1113,33 @@ public class WikiRestServiceImpl implements WikiRestService, ResourceContainer {
       wikiService.removeDraft(draftName);
       return Response.ok().cacheControl(cc).build();
     } catch (Exception e) {
+      return Response.status(HTTPStatus.INTERNAL_ERROR).cacheControl(cc).build();
+    }
+  }
+
+  /**
+   * Return an emotion icon
+   * @param uriInfo Uri of the wiki
+   * @param name Name of the emotion icon
+   * @return The response with the emotion icon
+   */
+  @GET
+  @Path("/emoticons/{name}")
+  public Response getEmotionIcon(@Context UriInfo uriInfo,
+                                @PathParam("name") String name) {
+    try {
+      EmotionIcon emotionIcon = wikiService.getEmotionIconByName(name);
+      if (emotionIcon == null) {
+        return Response.status(HTTPStatus.NOT_FOUND).build();
+      }
+
+      ByteArrayInputStream emotionIconImage = new ByteArrayInputStream(emotionIcon.getImage());
+
+      return Response.ok(emotionIconImage).cacheControl(cc).build();
+    } catch (Exception e) {
+      if (log.isDebugEnabled()) {
+        log.debug(String.format("Can't get emotion icon: %s", name), e);
+      }
       return Response.status(HTTPStatus.INTERNAL_ERROR).cacheControl(cc).build();
     }
   }

--- a/wiki-service/src/test/java/org/exoplatform/wiki/service/TestWikiRestService.java
+++ b/wiki-service/src/test/java/org/exoplatform/wiki/service/TestWikiRestService.java
@@ -1,0 +1,64 @@
+package org.exoplatform.wiki.service;
+
+import org.apache.commons.compress.utils.IOUtils;
+import org.exoplatform.wiki.WikiException;
+import org.exoplatform.wiki.mow.api.EmotionIcon;
+import org.exoplatform.wiki.rendering.RenderingService;
+import org.exoplatform.wiki.service.impl.WikiRestServiceImpl;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ */
+public class TestWikiRestService {
+
+  @Test
+  public void shouldGetEmotionIcon() throws WikiException, IOException {
+    // Given
+    WikiService wikiService = mock(WikiService.class);
+    RenderingService renderingService = mock(RenderingService.class);
+    WikiRestServiceImpl wikiRestService = new WikiRestServiceImpl(wikiService, renderingService);
+
+    EmotionIcon emotionIcon = new EmotionIcon();
+    emotionIcon.setName("test.gif");
+    emotionIcon.setImage("image".getBytes());
+
+    when(wikiService.getEmotionIconByName("test.gif")).thenReturn(emotionIcon);
+
+    // When
+    Response emotionIconResponse = wikiRestService.getEmotionIcon(null, "test.gif");
+
+    // Then
+    assertNotNull(emotionIconResponse);
+    assertEquals(200, emotionIconResponse.getStatus());
+    Object responseEntity = emotionIconResponse.getEntity();
+    assertNotNull(responseEntity);
+    assertArrayEquals(emotionIcon.getImage(), IOUtils.toByteArray((ByteArrayInputStream) responseEntity));
+  }
+
+  @Test
+  public void shouldGetNotFoundResponseWhenEmotionIconDoesNotExist() throws WikiException {
+    // Given
+    WikiService wikiService = mock(WikiService.class);
+    RenderingService renderingService = mock(RenderingService.class);
+    WikiRestServiceImpl wikiRestService = new WikiRestServiceImpl(wikiService, renderingService);
+
+    when(wikiService.getEmotionIconByName("test.gif")).thenReturn(null);
+
+    // When
+    Response emotionIconResponse = wikiRestService.getEmotionIcon(null, "test.gif");
+
+    // Then
+    assertNotNull(emotionIconResponse);
+    assertEquals(404, emotionIconResponse.getStatus());
+  }
+
+}

--- a/wiki-service/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/wiki-service/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.exoplatform.services.rest.impl.RuntimeDelegateImpl


### PR DESCRIPTION
This PR implements a new endpoint to retrieve emotion icons independently from the storage (JCR, JPA) and update the JCR data storage implementation to send the icon binary when getting an emotion icon. No need to update the JPA data storage implementation since it already send the icon binary.