### PR TITLE
WIKI-1213 : update Updated date when a page content is updated

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
@@ -903,6 +903,11 @@ public class WikiServiceImpl implements WikiService, Startable {
 
   @Override
   public void updatePage(Page page, PageUpdateType updateType) throws WikiException {
+    // update updated date if the page content has been updated
+    if(PageUpdateType.EDIT_PAGE_CONTENT.equals(updateType) || PageUpdateType.EDIT_PAGE_CONTENT_AND_TITLE.equals(updateType)) {
+      page.setUpdatedDate(Calendar.getInstance().getTime());
+    }
+
     dataStorage.updatePage(page);
 
     invalidateCache(page);


### PR DESCRIPTION
This is a proposal PR to fix https://jira.exoplatform.org/browse/WIKI-1213.
This bug occurs only with wiki-rdbms addon since in standard PLF, the updated date is updated by the JCR data storage service, which is not a good thing IMO. This rule (updating the update date) is not dependent on the storage implementation, so it should not be done in the storage service (that what wiki-rdbms does, it does not update the date, just store the data as is).
The fix makes the service API update the updated date as soon as the content of the wiki page is changed. This prevents to set an arbitrary updated date in this case. I am not sure it is the good solution. An alternative solution is to not change the updated date in the service and set the right updated date explicitly each time before calling the API.