### PR TITLE
WIKI-1324 : drop constraints on columns WIKI_PAGE_ATTACHMENTS.UPDATED_DATE and WIKI_DRAFT_ATTACHMENTS.UPDATED_DATE before dropping the columns for MSSQL

### DIFF
--- a/wiki-jpa-dao/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
+++ b/wiki-jpa-dao/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
@@ -485,6 +485,12 @@
   </changeSet>
 
   <changeSet id="1.0.0-42" author="wiki">
+    <validCheckSum>7:7d4a990e4664c19155e9beb35e6e8ebc</validCheckSum>
+    <sql dbms="mssql">
+      IF EXISTS(SELECT * FROM sys.objects WHERE type='D' AND NAME='DF_WIKI_PAGE_ATTACHMENTS_UPDATED_DATE')
+        ALTER TABLE WIKI_PAGE_ATTACHMENTS
+          DROP CONSTRAINT DF_WIKI_PAGE_ATTACHMENTS_UPDATED_DATE
+    </sql>
     <dropColumn tableName="WIKI_PAGE_ATTACHMENTS">
       <column name="NAME"/>
       <column name="UPDATED_DATE"/>
@@ -496,6 +502,12 @@
   </changeSet>
 
   <changeSet id="1.0.0-43" author="wiki">
+    <validCheckSum>7:44cfbff48ff23a305643392177e0c79a</validCheckSum>
+    <sql dbms="mssql">
+      IF EXISTS(SELECT * FROM sys.objects WHERE type='D' AND NAME='DF_WIKI_DRAFT_ATTACHMENTS_UPDATED_DATE')
+        ALTER TABLE WIKI_DRAFT_ATTACHMENTS
+          DROP CONSTRAINT DF_WIKI_DRAFT_ATTACHMENTS_UPDATED_DATE
+    </sql>
     <dropColumn tableName="WIKI_DRAFT_ATTACHMENTS">
       <column name="NAME"/>
       <column name="UPDATED_DATE"/>


### PR DESCRIPTION
MSSQL adds a constraint on columns for default date value and requires to drop this constraint before dropping the column. This PR adds the 2 SQL queries to drop these constraints and adds a validChecksum on the modified changeSets to make sure it works fine on existing installations.