### PR TITLE
PLF-7795 : retrieve name and pageName also in search results to be able to construct the url

### DIFF
--- a/wiki-jpa-dao/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticUnifiedSearchServiceConnector.java
+++ b/wiki-jpa-dao/src/main/java/org/exoplatform/wiki/jpa/search/WikiElasticUnifiedSearchServiceConnector.java
@@ -62,6 +62,8 @@ public class WikiElasticUnifiedSearchServiceConnector extends ElasticSearchServi
 
     List<String> fields = new ArrayList<>();
     fields.add(getTitleElasticFieldName());
+    fields.add("name");
+    fields.add("pageName");
     fields.add("title");
     fields.add("wikiType");
     fields.add("wikiOwner");

--- a/wiki-jpa-dao/src/test/java/org/exoplatform/wiki/jpa/search/WikiElasticsearchIntegrationTest.java
+++ b/wiki-jpa-dao/src/test/java/org/exoplatform/wiki/jpa/search/WikiElasticsearchIntegrationTest.java
@@ -1,0 +1,60 @@
+/*
+ *
+ *  * Copyright (C) 2003-2015 eXo Platform SAS.
+ *  *
+ *  * This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Affero General Public License
+ *  as published by the Free Software Foundation; either version 3
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see<http://www.gnu.org/licenses/>.
+ *  
+ */
+
+package org.exoplatform.wiki.jpa.search;
+
+import org.exoplatform.commons.api.search.data.SearchContext;
+import org.exoplatform.commons.api.search.data.SearchResult;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.web.controller.router.Router;
+import org.exoplatform.wiki.jpa.BaseWikiESIntegrationTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Collection;
+
+/**
+ * Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com
+ * 10/21/15
+ */
+public class WikiElasticsearchIntegrationTest extends BaseWikiESIntegrationTest {
+
+    WikiElasticUnifiedSearchServiceConnector searchServiceConnector;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        searchServiceConnector = CommonsUtils.getService(WikiElasticUnifiedSearchServiceConnector.class);
+    }
+
+    public void testFindPageByTitle() throws Exception {
+        // Given
+        SearchContext searchContext = new SearchContext(CommonsUtils.getService(Router.class), "intranet");
+        // When
+        indexPage("My_name", "My title", "This is the content of my Page", "This is a comment", "BCH", null);
+        // Then
+        Collection<SearchResult> searchResults = searchServiceConnector.search(searchContext, "title", null, 0, 50, null, null);
+        assertNotNull(searchResults);
+        assertEquals(1, searchResults.size());
+        SearchResult foundPage = searchResults.iterator().next();
+        assertEquals("My title", foundPage.getTitle());
+        assertEquals("... My <strong>title</strong>", foundPage.getExcerpt());
+        assertEquals("/portal/intranet/wiki/My_name", foundPage.getUrl());
+    }
+}

--- a/wiki-jpa-dao/src/test/resources/conf/standalone/components-configuration.xml
+++ b/wiki-jpa-dao/src/test/resources/conf/standalone/components-configuration.xml
@@ -93,6 +93,97 @@
     <type>org.exoplatform.commons.search.es.client.ElasticContentRequestBuilder</type>
   </component>
 
+  <component>
+    <key>org.exoplatform.portal.config.UserACL</key>
+    <type>org.exoplatform.portal.config.UserACL</type>
+    <init-params>
+      <value-param>
+        <name>super.user</name>
+        <value>root</value>
+      </value-param>
+      <value-param>
+        <name>guests.group</name>
+        <value>/platform/guests</value>
+      </value-param>
+      <value-param>
+        <name>navigation.creator.membership.type</name>
+        <value>manager</value>
+      </value-param>
+    </init-params>
+  </component>
+  <component>
+    <key>org.exoplatform.services.cache.CacheService</key>
+    <jmx-name>cache:type=CacheService</jmx-name>
+    <type>org.exoplatform.services.cache.impl.CacheServiceImpl</type>
+    <init-params>
+      <object-param>
+        <name>cache.config.default</name>
+        <object type="org.exoplatform.services.cache.ExoCacheConfig">
+          <field name="name">
+            <string>default</string>
+          </field>
+          <field name="maxSize">
+            <int>30000</int>
+          </field>
+          <field name="liveTime">
+            <long>60000</long>
+          </field>
+          <field name="distributed">
+            <boolean>false</boolean>
+          </field>
+          <field name="implementation">
+            <string>org.exoplatform.services.cache.concurrent.ConcurrentFIFOExoCache</string>
+          </field>
+        </object>
+      </object-param>
+    </init-params>
+  </component>
+  <component>
+    <key>org.exoplatform.wiki.rendering.RenderingService</key>
+    <type>org.exoplatform.wiki.rendering.impl.RenderingServiceImpl</type>
+  </component>
+
+  <component>
+    <key>org.exoplatform.wiki.service.WikiService</key>
+    <type>org.exoplatform.wiki.service.impl.WikiServiceImpl</type>
+    <init-params>
+      <value-param>
+        <name>wiki.editPage.livingTime</name>
+        <value>${wiki.editPage.livingTime:1800000}</value>
+        <!-- 30m * 60s * 1000ms -->
+      </value-param>
+      <value-param>
+        <name>attachment.upload.limit</name>
+        <value>10</value>
+      </value-param>
+      <values-param>
+        <name>xwiki/2.0</name>
+        <value>jar:/wikisyntax/help/xWiki2.0_Short.txt</value>
+        <value>jar:/wikisyntax/help/xWiki2.0_Full.txt</value>
+      </values-param>
+      <properties-param>
+        <name>preferences</name>
+        <property name="defaultSyntax" value="xwiki/2.0"/>
+      </properties-param>
+    </init-params>
+  </component>
+  <component>
+    <type>org.exoplatform.wiki.jpa.search.WikiElasticUnifiedSearchServiceConnector</type>
+    <init-params>
+      <properties-param>
+        <name>constructor.params</name>
+        <property name="searchType" value="wiki"/>
+        <property name="displayName" value="Wiki"/>
+        <property name="index" value="wiki_alias"/>
+        <property name="type" value="wiki-page,wiki-attachment"/>
+        <property name="enable" value="${exo.unified-search.connector.wiki.enable:true}"/>
+        <property name="titleField" value="title"/>
+        <property name="updatedDateField" value="updatedDate"/>
+        <property name="searchFields" value="name,title,content,comment,attachment.content"/>
+      </properties-param>
+    </init-params>
+  </component>
+
 
   <component>
     <type>org.exoplatform.commons.persistence.impl.EntityManagerService</type>


### PR DESCRIPTION
This issue is a regression of https://jira.exoplatform.org/browse/PLF-7144. The name and pageName source fields have been removed form search results but there are needed to construct the URLs. This PR adds them back and adds integration tests.