### PR TITLE
WIKI-1294 : save edition in progress even for the first draft of a user for a given page

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
@@ -1105,11 +1105,10 @@ public class WikiRestServiceImpl implements WikiRestService, ResourceContainer {
         }
         draftPage.setContent(content);
         wikiService.updatePage(draftPage, null);
-
-        // Log the editting time for current user
-        Utils.logEditPageTime(param, Utils.getCurrentUser(), System.currentTimeMillis(), draftPage.getName(), isNewPage);
-
       }
+
+      // Log the editting time for current user
+      Utils.logEditPageTime(param, Utils.getCurrentUser(), System.currentTimeMillis(), draftPage.getName(), isNewPage);
       
       // Notify to client that saved draft success
       return Response.ok(new DraftData(draftPage.getName()), MediaType.APPLICATION_JSON).cacheControl(cc).build();


### PR DESCRIPTION
When an user edits a page and updates some content, when the draft is saved (after 30 seconds by default), we save that the page is being edited by the user.
This is done correctly, except for the first draft (the first draft after an user edited a page content).
This fix do it in all cases (not only the first draft).