### PR TITLE
WIKI-1392 : encode HTML contents at display time only

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiRestServiceImpl.java
@@ -55,12 +55,12 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.commons.utils.StringCommonUtils;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.rendering.syntax.Syntax;
 
 import org.exoplatform.common.http.HTTPStatus;
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.commons.utils.MimeTypeResolver;
 import org.exoplatform.container.ExoContainerContext;
@@ -315,7 +315,7 @@ public class WikiRestServiceImpl implements WikiRestService, ResourceContainer {
       EnvironmentContext env = EnvironmentContext.getCurrent();
       HttpServletRequest request = (HttpServletRequest) env.get(HttpServletRequest.class);
 
-      sanitizeWikiTree(responseData, request.getLocale());
+      encodeWikiTree(responseData, request.getLocale());
       return Response.ok(new BeanToJsons(responseData), MediaType.APPLICATION_JSON).cacheControl(cc).build();
     } catch (Exception e) {
       if (log.isErrorEnabled()) {
@@ -1181,7 +1181,7 @@ public class WikiRestServiceImpl implements WikiRestService, ResourceContainer {
     }
   }
 
-  private void sanitizeWikiTree(List<JsonNodeData> responseData, Locale locale) throws Exception {
+  private void encodeWikiTree(List<JsonNodeData> responseData, Locale locale) throws Exception {
     ResourceBundle resourceBundle = resourceBundleService.getResourceBundle(Utils.WIKI_RESOUCE_BUNDLE_NAME, locale);
     String untitledLabel = "";
     if (resourceBundle == null) {
@@ -1192,12 +1192,12 @@ public class WikiRestServiceImpl implements WikiRestService, ResourceContainer {
     }
 
     for (JsonNodeData data : responseData) {
-      data.setName(HTMLSanitizer.sanitize(data.getName()));
+      data.setName(StringCommonUtils.encodeSpecialCharForSimpleInput(data.getName()));
       if (StringUtils.isBlank(data.getName())) {
         data.setName(untitledLabel);
       }
       if (CollectionUtils.isNotEmpty(data.children)) {
-        sanitizeWikiTree(data.children, locale);
+        encodeWikiTree(data.children, locale);
       }
     }
   }

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiPageTitleControlArea.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiPageTitleControlArea.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.ResourceBundle;
 
-import org.exoplatform.commons.utils.StringCommonUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.webui.application.WebuiRequestContext;
@@ -141,7 +140,7 @@ public class UIWikiPageTitleControlArea extends UIWikiExtensionContainer {
                              newTitle);
       if (renamed) {
         page.setName(newName);
-        page.setTitle(StringCommonUtils.encodeSpecialCharForSimpleInput(newTitle));
+        page.setTitle(newTitle);
         pageParams.setPageName(newName);
         page.setUrl(Utils.getURLFromParams(pageParams));
         Utils.redirect(pageParams, WikiMode.VIEW);

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/EditPageActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/EditPageActionComponent.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 
-import org.exoplatform.commons.utils.StringCommonUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.config.annotation.EventConfig;
@@ -99,7 +98,7 @@ public class EditPageActionComponent extends AbstractEventActionComponent {
         content = renderingService.getContentOfSection(content, page.getSyntax(), sectionIndex);
         titleInput.setEditable(false);
       }
-      titleInput.setValue(StringCommonUtils.decodeSpecialCharToHTMLnumber(title));
+      titleInput.setValue(title);
       pageEditForm.setTitle(title) ;
       markupInput.setValue(content);
       commentInput.setValue("");

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
@@ -24,8 +24,6 @@ import java.util.ResourceBundle;
 import org.apache.commons.lang.StringUtils;
 import org.xwiki.rendering.syntax.Syntax;
 
-import org.exoplatform.commons.utils.HTMLSanitizer;
-import org.exoplatform.commons.utils.StringCommonUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -121,9 +119,6 @@ public class SavePageActionComponent extends UIComponent {
         }
 
         String title = titleInput.getValue().trim();
-        title = StringCommonUtils.encodeSpecialCharForSimpleInput(title);
-        title = title == null ? null : HTMLSanitizer.sanitize(title);
-        titleInput.setValue(StringCommonUtils.decodeSpecialCharToHTMLnumber(title));
         if (StringUtils.isBlank(title)) {
           event.getRequestContext()
                .getUIApplication()
@@ -211,7 +206,7 @@ public class SavePageActionComponent extends UIComponent {
               page.setComment(commentInput.getValue());
               page.setAuthor(currentUser);
               page.setSyntax(syntaxId);
-              pageTitleControlForm.getUIFormInputInfo().setValue(StringCommonUtils.decodeSpecialCharToHTMLnumber(HTMLSanitizer.sanitize(title)));
+              pageTitleControlForm.getUIFormInputInfo().setValue(title);
               pageParams.setPageName(page.getName());
               page.setUrl(Utils.getURLFromParams(pageParams));
 

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SaveTemplateActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SaveTemplateActionComponent.java
@@ -22,8 +22,6 @@ import java.util.List;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 
-import org.exoplatform.commons.utils.HTMLSanitizer;
-import org.exoplatform.commons.utils.StringCommonUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -99,9 +97,6 @@ public class SaveTemplateActionComponent extends UIComponent {
       UIFormStringInput descriptionInput = pageEditForm.findComponentById(UIWikiTemplateDescriptionContainer.FIELD_DESCRIPTION);
       UIFormTextAreaInput markupInput = pageEditForm.findComponentById(UIWikiPageEditForm.FIELD_CONTENT);
       String templateTitle = titleInput.getValue();
-      templateTitle = StringCommonUtils.encodeSpecialCharForSimpleInput(templateTitle);
-      templateTitle = templateTitle == null ? null : HTMLSanitizer.sanitize(templateTitle);
-      titleInput.setValue(StringCommonUtils.decodeSpecialCharToHTMLnumber(templateTitle));
       if (StringUtils.isBlank(templateTitle)) {
         isError = true;
         appMsg = new ApplicationMessage("WikiPageNameValidator.msg.EmptyTitle",


### PR DESCRIPTION
HTML contents (like activities contents) must be interpreted as HTML (so they should be sanitized but not encoded).
Non-HTML contents (like wiki page title, wiki template page title, ...) must not be interpreted as HTML (so they should be encoded).
This fix :
* do not encode page title when storing it in the database (stored as is in the database)
* encode wiki pages title in wiki tree when displaying it (instead of sanitizing them)

So if a page has the title "<b>Page 1</b>", it will be displayed as is on tp the page and in the wiki pages tree.