### PR TITLE
WIKI-1407 : add index on WIKI_PAGES.NAME

### DIFF
--- a/wiki-jpa-dao/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
+++ b/wiki-jpa-dao/src/main/resources/db/changelog/wiki.db.changelog-1.0.0.xml
@@ -634,4 +634,11 @@
     <addUniqueConstraint columnNames="OWNER, TYPE" tableName="WIKI_WIKIS"
                          constraintName="UK_WIKI_WIKIS_OWNER_TYPE_01"/>
   </changeSet>
+
+  <changeSet id="1.0.0-55" author="wiki">
+    <createIndex tableName="WIKI_PAGES" indexName="IDX_WIKI_PAGES_01">
+      <column name="NAME"/>
+    </createIndex>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
The sql query fetching a page by its type/owner/name is used a lot. Since there is no index on the WIKI_PAGES.NAME, it causes slowness and performances issues.
This fix adds an index on the field WIKI_PAGES.NAME.