### PR TITLE
WIKI-1411 : consider new line characters when detecting missing columns in wiki section macro

### DIFF
--- a/wiki-renderer/src/main/java/org/exoplatform/wiki/rendering/macro/section/SectionMacro.java
+++ b/wiki-renderer/src/main/java/org/exoplatform/wiki/rendering/macro/section/SectionMacro.java
@@ -62,7 +62,7 @@ public class SectionMacro extends AbstractMacro<SectionMacroParameters> {
   private static final String MACRO_NAME                 = "Section";
   
   private static final Pattern COLUMN_PATTERN 
-                                  = Pattern.compile("(\\{\\{column\\/\\}\\}|\\{\\{column\\}\\}.*\\{\\{\\/column\\}\\})");
+                                  = Pattern.compile("(\\{\\{column\\/\\}\\}|\\{\\{column\\}\\}.*\\{\\{\\/column\\}\\})", Pattern.DOTALL);
 
   @Inject
   private ComponentManager    componentManager;

--- a/wiki-service/src/test/java/org/exoplatform/wiki/rendering/impl/TestMacroRendering.java
+++ b/wiki-service/src/test/java/org/exoplatform/wiki/rendering/impl/TestMacroRendering.java
@@ -78,6 +78,7 @@ public class TestMacroRendering extends AbstractRenderingTestCase {
     assertEquals(expectedHtml, renderingService.render("{{section}}Text without column{{/section}}", Syntax.XWIKI_2_0.toIdString(), Syntax.XHTML_1_0.toIdString(), false));
     expectedHtml = "<div><div style=\"float:left;width:49.2%;padding-right:1.5%;\"><p>Column one text goes here</p></div><div style=\"float:left;width:49.2%;\"><p>Column two text goes here</p></div><div style=\"clear:both\"></div></div>";
     assertEquals(expectedHtml, renderingService.render("{{section}}\n\n{{column}}Column one text goes here{{/column}}\n\n{{column}}Column two text goes here{{/column}}\n\n{{/section}}", Syntax.XWIKI_2_0.toIdString(), Syntax.XHTML_1_0.toIdString(), false));
+    assertEquals(expectedHtml, renderingService.render("{{section}}\n\n{{column}}\n\nColumn one text goes here\n\n{{/column}}\n\n{{column}}\n\nColumn two text goes here\n\n{{/column}}\n\n{{/section}}", Syntax.XWIKI_2_0.toIdString(), Syntax.XHTML_1_0.toIdString(), false));
   }
   
   public void testRenderNoFormatMacro() throws Exception {


### PR DESCRIPTION
The regex allowing to detect if the content of a section macro missed columns tags did not consider the new line character.
This fix adds the option in the regex to consider these characters.