### PR TITLE
MAINT-25804 : Fix problem loading right wiki url for tree pages

### DIFF
--- a/wiki-webui/pom.xml
+++ b/wiki-webui/pom.xml
@@ -209,6 +209,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/commons/Utils.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/commons/Utils.java
@@ -41,8 +41,11 @@ import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityConstants;
+import org.exoplatform.social.core.space.SpaceApplication;
+import org.exoplatform.social.core.space.SpaceTemplate;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.core.space.spi.SpaceTemplateService;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.application.portlet.PortletRequestContext;
 import org.exoplatform.webui.core.UIComponent;
@@ -169,7 +172,7 @@ public class Utils {
   }
 
   public static String getSpaceHomeURL(String spaceGroupId) {
-    SpaceService spaceService = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(SpaceService.class);
+    SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     Space space = spaceService.getSpaceByGroupId(spaceGroupId);
     String spaceLink = org.exoplatform.social.webui.Utils.getSpaceHomeURL(space);
     return spaceLink;
@@ -185,7 +188,6 @@ public class Utils {
       if (!spaceUrl.toString().endsWith("/")) {
         spaceUrl.append("/");
       }
-      // spaceUrl.append("wiki/");
       spaceUrl.append(getWikiAppNameInSpace(params.getOwner())).append("/");
       if (!StringUtils.isEmpty(params.getPageName())) {
         spaceUrl.append(params.getPageName());
@@ -196,14 +198,15 @@ public class Utils {
   }
 
   private static String getWikiAppNameInSpace(String spaceId) {
-    SpaceService spaceService = ExoContainerContext.getService(SpaceService.class);
+    SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     Space space = spaceService.getSpaceByGroupId(spaceId);
-    String apps = space.getApp();
-    if (apps != null) {
-      for (String app : apps.split(",")) {
-        String[] appInfos = app.split(":");
-        if (appInfos.length > 1 && "WikiPortlet".equals(appInfos[0])) {
-          return appInfos[1];
+    SpaceTemplateService spaceTemplateService = CommonsUtils.getService(SpaceTemplateService.class);
+    SpaceTemplate spaceTemplate = spaceTemplateService.getSpaceTemplateByName(space.getTemplate());
+    List<SpaceApplication> spaceTemplateApplications = spaceTemplate.getSpaceApplicationList();
+    if (spaceTemplateApplications != null) {
+      for (SpaceApplication spaceApplication : spaceTemplateApplications) {
+        if("WikiPortlet".equals(spaceApplication.getPortletName())){
+          return spaceApplication.getUri();
         }
       }
     }

--- a/wiki-webui/src/test/java/org/exoplatform/wiki/TestUtils.java
+++ b/wiki-webui/src/test/java/org/exoplatform/wiki/TestUtils.java
@@ -17,9 +17,70 @@
 package org.exoplatform.wiki;
 
 import junit.framework.TestCase;
+import org.apache.commons.lang.StringUtils;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.social.core.space.SpaceApplication;
+import org.exoplatform.social.core.space.SpaceTemplate;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.core.space.spi.SpaceTemplateService;
+import org.exoplatform.wiki.commons.Utils;
+import org.exoplatform.wiki.service.WikiPageParams;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CommonsUtils.class, org.exoplatform.social.webui.Utils.class})
 public class TestUtils extends TestCase {
 
   public void testGetURLFromParams() throws Exception {
+    // Mocks
+    SpaceService spaceService = Mockito.mock(SpaceService.class);
+    SpaceTemplateService spaceTemplateService = Mockito.mock(SpaceTemplateService.class);
+    PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.mockStatic(org.exoplatform.social.webui.Utils.class);
+
+    // Returned Objects from mocks
+    List<SpaceApplication> spaceApplicationList = new ArrayList<>();
+    SpaceApplication spaceApplication1 = new SpaceApplication();
+    spaceApplication1.setPortletName("WikiPortlet");
+    spaceApplication1.setUri("wiki");
+    spaceApplicationList.add(spaceApplication1);
+    SpaceApplication spaceApplication2 = new SpaceApplication();
+    spaceApplication2.setPortletName("SpaceSettingPortlet");
+    spaceApplication2.setUri("settings");
+    spaceApplicationList.add(spaceApplication2);
+    SpaceTemplate spaceTemplate = new SpaceTemplate();
+    spaceTemplate.setName("community");
+    spaceTemplate.setSpaceApplicationList(spaceApplicationList);
+    Space space = new Space();
+    space.setGroupId("/spaces/spaceTest");
+    space.setTemplate(spaceTemplate.getName());
+
+    // When
+    when(CommonsUtils.getService(SpaceService.class)).thenReturn(spaceService);
+    when(CommonsUtils.getService(SpaceTemplateService.class)).thenReturn(spaceTemplateService);
+    when(org.exoplatform.social.webui.Utils.getSpaceHomeURL(space)).thenReturn("/portal/g/:spaces:spaceTest/spaceTest");
+    when(spaceService.getSpaceByGroupId(Matchers.eq("/spaces/spaceTest"))).thenReturn(space);
+    when(spaceTemplateService.getSpaceTemplateByName(Matchers.eq("community"))).thenReturn(spaceTemplate);
+
+    // Then
+    WikiPageParams params = new WikiPageParams();
+    params.setOwner("");
+    assertEquals(Utils.getURLFromParams(params), StringUtils.EMPTY);
+    params.setOwner("/spaces/spaceTest");
+    params.setType("");
+    assertEquals(Utils.getURLFromParams(params), StringUtils.EMPTY);
+    params.setType("group");
+    assertEquals(Utils.getURLFromParams(params), "/portal/g/:spaces:spaceTest/spaceTest/wiki/");
   }
 }


### PR DESCRIPTION
Getting wiki URI from installed apps returns the Wiki name (WikiPortlet)
Instead we used the spaceTemplate service to get the good Wiki URI from the configured URI in the list of applications.